### PR TITLE
feat: add user profile management

### DIFF
--- a/WhatsAppChat.Api/Controllers/ProfileController.cs
+++ b/WhatsAppChat.Api/Controllers/ProfileController.cs
@@ -1,0 +1,64 @@
+using System.Security.Claims;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using WhatsAppChat.Application.DTOs.Profile;
+using WhatsAppChat.Application.Features.Profile.Commands.UpdateProfile;
+using WhatsAppChat.Application.Features.Profile.Commands.UploadAvatar;
+using WhatsAppChat.Application.Features.Profile.Commands.UpdatePrivacySettings;
+using WhatsAppChat.Application.Features.Profile.Queries.GetMyProfile;
+using WhatsAppChat.Application.Features.Profile.Queries.GetUserProfile;
+
+namespace WhatsAppChat.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class ProfileController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public ProfileController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    private string GetUserId() => User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+
+    [HttpGet("me")]
+    public async Task<IActionResult> GetMyProfile()
+    {
+        var result = await _mediator.Send(new GetMyProfileQuery(GetUserId()));
+        return Ok(result);
+    }
+
+    [HttpGet("{userId}")]
+    public async Task<IActionResult> GetUserProfile(string userId)
+    {
+        var result = await _mediator.Send(new GetUserProfileQuery(userId));
+        return Ok(result);
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdateProfile(UpdateProfileDto dto)
+    {
+        var result = await _mediator.Send(new UpdateProfileCommand(GetUserId(), dto));
+        return Ok(result);
+    }
+
+    [HttpPost("avatar")]
+    public async Task<IActionResult> UploadAvatar(IFormFile file)
+    {
+        using var stream = file.OpenReadStream();
+        var result = await _mediator.Send(new UploadAvatarCommand(GetUserId(), stream, file.FileName));
+        return Ok(result);
+    }
+
+    [HttpPut("privacy")]
+    public async Task<IActionResult> UpdatePrivacy(UpdatePrivacyDto dto)
+    {
+        var result = await _mediator.Send(new UpdatePrivacySettingsCommand(GetUserId(), dto));
+        return Ok(result);
+    }
+}

--- a/WhatsAppChat.Application/Common/Interfaces/IAvatarStorageService.cs
+++ b/WhatsAppChat.Application/Common/Interfaces/IAvatarStorageService.cs
@@ -1,0 +1,9 @@
+using System.IO;
+using System.Threading;
+
+namespace WhatsAppChat.Application.Common.Interfaces;
+
+public interface IAvatarStorageService
+{
+    Task<string> SaveAvatarAsync(string userId, Stream avatarStream, string fileName, CancellationToken cancellationToken = default);
+}

--- a/WhatsAppChat.Application/DTOs/Profile/AvatarUploadResultDto.cs
+++ b/WhatsAppChat.Application/DTOs/Profile/AvatarUploadResultDto.cs
@@ -1,0 +1,3 @@
+namespace WhatsAppChat.Application.DTOs.Profile;
+
+public record AvatarUploadResultDto(string AvatarUrl);

--- a/WhatsAppChat.Application/DTOs/Profile/ProfileDto.cs
+++ b/WhatsAppChat.Application/DTOs/Profile/ProfileDto.cs
@@ -1,0 +1,3 @@
+namespace WhatsAppChat.Application.DTOs.Profile;
+
+public record ProfileDto(string Id, string? DisplayName, string? AvatarUrl, string? About, DateTime? LastSeen, string LastSeenPrivacy);

--- a/WhatsAppChat.Application/DTOs/Profile/UpdatePrivacyDto.cs
+++ b/WhatsAppChat.Application/DTOs/Profile/UpdatePrivacyDto.cs
@@ -1,0 +1,3 @@
+namespace WhatsAppChat.Application.DTOs.Profile;
+
+public record UpdatePrivacyDto(string LastSeenPrivacy);

--- a/WhatsAppChat.Application/DTOs/Profile/UpdateProfileDto.cs
+++ b/WhatsAppChat.Application/DTOs/Profile/UpdateProfileDto.cs
@@ -1,0 +1,3 @@
+namespace WhatsAppChat.Application.DTOs.Profile;
+
+public record UpdateProfileDto(string DisplayName, string? About);

--- a/WhatsAppChat.Application/Features/Profile/Commands/UpdatePrivacySettings/UpdatePrivacySettingsCommand.cs
+++ b/WhatsAppChat.Application/Features/Profile/Commands/UpdatePrivacySettings/UpdatePrivacySettingsCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WhatsAppChat.Application.DTOs.Profile;
+
+namespace WhatsAppChat.Application.Features.Profile.Commands.UpdatePrivacySettings;
+
+public record UpdatePrivacySettingsCommand(string UserId, UpdatePrivacyDto PrivacyDto) : IRequest<ProfileDto>;

--- a/WhatsAppChat.Application/Features/Profile/Commands/UpdatePrivacySettings/UpdatePrivacySettingsCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Profile/Commands/UpdatePrivacySettings/UpdatePrivacySettingsCommandHandler.cs
@@ -1,0 +1,36 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using WhatsAppChat.Application.DTOs.Profile;
+using WhatsAppChat.Domain.Entities;
+using WhatsAppChat.Domain.Enums;
+
+namespace WhatsAppChat.Application.Features.Profile.Commands.UpdatePrivacySettings;
+
+public class UpdatePrivacySettingsCommandHandler : IRequestHandler<UpdatePrivacySettingsCommand, ProfileDto>
+{
+    private readonly UserManager<AppUser> _userManager;
+
+    public UpdatePrivacySettingsCommandHandler(UserManager<AppUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    public async Task<ProfileDto> Handle(UpdatePrivacySettingsCommand request, CancellationToken cancellationToken)
+    {
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            throw new KeyNotFoundException("User not found");
+        }
+
+        if (!Enum.TryParse<LastSeenPrivacy>(request.PrivacyDto.LastSeenPrivacy, true, out var privacy))
+        {
+            throw new ArgumentException("Invalid privacy option");
+        }
+
+        user.LastSeenPrivacy = privacy;
+        await _userManager.UpdateAsync(user);
+
+        return new ProfileDto(user.Id, user.DisplayName, user.AvatarUrl, user.About, user.LastSeen, user.LastSeenPrivacy.ToString());
+    }
+}

--- a/WhatsAppChat.Application/Features/Profile/Commands/UpdatePrivacySettings/UpdatePrivacySettingsCommandValidator.cs
+++ b/WhatsAppChat.Application/Features/Profile/Commands/UpdatePrivacySettings/UpdatePrivacySettingsCommandValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using WhatsAppChat.Domain.Enums;
+
+namespace WhatsAppChat.Application.Features.Profile.Commands.UpdatePrivacySettings;
+
+public class UpdatePrivacySettingsCommandValidator : AbstractValidator<UpdatePrivacySettingsCommand>
+{
+    public UpdatePrivacySettingsCommandValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.PrivacyDto.LastSeenPrivacy)
+            .Must(p => Enum.TryParse<LastSeenPrivacy>(p, true, out _))
+            .WithMessage("Invalid privacy option");
+    }
+}

--- a/WhatsAppChat.Application/Features/Profile/Commands/UpdateProfile/UpdateProfileCommand.cs
+++ b/WhatsAppChat.Application/Features/Profile/Commands/UpdateProfile/UpdateProfileCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WhatsAppChat.Application.DTOs.Profile;
+
+namespace WhatsAppChat.Application.Features.Profile.Commands.UpdateProfile;
+
+public record UpdateProfileCommand(string UserId, UpdateProfileDto UpdateDto) : IRequest<ProfileDto>;

--- a/WhatsAppChat.Application/Features/Profile/Commands/UpdateProfile/UpdateProfileCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Profile/Commands/UpdateProfile/UpdateProfileCommandHandler.cs
@@ -1,0 +1,31 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using WhatsAppChat.Application.DTOs.Profile;
+using WhatsAppChat.Domain.Entities;
+
+namespace WhatsAppChat.Application.Features.Profile.Commands.UpdateProfile;
+
+public class UpdateProfileCommandHandler : IRequestHandler<UpdateProfileCommand, ProfileDto>
+{
+    private readonly UserManager<AppUser> _userManager;
+
+    public UpdateProfileCommandHandler(UserManager<AppUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    public async Task<ProfileDto> Handle(UpdateProfileCommand request, CancellationToken cancellationToken)
+    {
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            throw new KeyNotFoundException("User not found");
+        }
+
+        user.DisplayName = request.UpdateDto.DisplayName;
+        user.About = request.UpdateDto.About;
+        await _userManager.UpdateAsync(user);
+
+        return new ProfileDto(user.Id, user.DisplayName, user.AvatarUrl, user.About, user.LastSeen, user.LastSeenPrivacy.ToString());
+    }
+}

--- a/WhatsAppChat.Application/Features/Profile/Commands/UpdateProfile/UpdateProfileCommandValidator.cs
+++ b/WhatsAppChat.Application/Features/Profile/Commands/UpdateProfile/UpdateProfileCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Profile.Commands.UpdateProfile;
+
+public class UpdateProfileCommandValidator : AbstractValidator<UpdateProfileCommand>
+{
+    public UpdateProfileCommandValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.UpdateDto.DisplayName).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/Features/Profile/Commands/UploadAvatar/UploadAvatarCommand.cs
+++ b/WhatsAppChat.Application/Features/Profile/Commands/UploadAvatar/UploadAvatarCommand.cs
@@ -1,0 +1,7 @@
+using System.IO;
+using MediatR;
+using WhatsAppChat.Application.DTOs.Profile;
+
+namespace WhatsAppChat.Application.Features.Profile.Commands.UploadAvatar;
+
+public record UploadAvatarCommand(string UserId, Stream AvatarStream, string FileName) : IRequest<AvatarUploadResultDto>;

--- a/WhatsAppChat.Application/Features/Profile/Commands/UploadAvatar/UploadAvatarCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Profile/Commands/UploadAvatar/UploadAvatarCommandHandler.cs
@@ -1,0 +1,33 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using WhatsAppChat.Application.Common.Interfaces;
+using WhatsAppChat.Application.DTOs.Profile;
+using WhatsAppChat.Domain.Entities;
+
+namespace WhatsAppChat.Application.Features.Profile.Commands.UploadAvatar;
+
+public class UploadAvatarCommandHandler : IRequestHandler<UploadAvatarCommand, AvatarUploadResultDto>
+{
+    private readonly UserManager<AppUser> _userManager;
+    private readonly IAvatarStorageService _avatarStorage;
+
+    public UploadAvatarCommandHandler(UserManager<AppUser> userManager, IAvatarStorageService avatarStorage)
+    {
+        _userManager = userManager;
+        _avatarStorage = avatarStorage;
+    }
+
+    public async Task<AvatarUploadResultDto> Handle(UploadAvatarCommand request, CancellationToken cancellationToken)
+    {
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            throw new KeyNotFoundException("User not found");
+        }
+
+        var url = await _avatarStorage.SaveAvatarAsync(user.Id, request.AvatarStream, request.FileName, cancellationToken);
+        user.AvatarUrl = url;
+        await _userManager.UpdateAsync(user);
+        return new AvatarUploadResultDto(url);
+    }
+}

--- a/WhatsAppChat.Application/Features/Profile/Commands/UploadAvatar/UploadAvatarCommandValidator.cs
+++ b/WhatsAppChat.Application/Features/Profile/Commands/UploadAvatar/UploadAvatarCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Profile.Commands.UploadAvatar;
+
+public class UploadAvatarCommandValidator : AbstractValidator<UploadAvatarCommand>
+{
+    public UploadAvatarCommandValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.FileName).NotEmpty();
+        RuleFor(x => x.AvatarStream).NotNull();
+    }
+}

--- a/WhatsAppChat.Application/Features/Profile/Queries/GetMyProfile/GetMyProfileQuery.cs
+++ b/WhatsAppChat.Application/Features/Profile/Queries/GetMyProfile/GetMyProfileQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WhatsAppChat.Application.DTOs.Profile;
+
+namespace WhatsAppChat.Application.Features.Profile.Queries.GetMyProfile;
+
+public record GetMyProfileQuery(string UserId) : IRequest<ProfileDto>;

--- a/WhatsAppChat.Application/Features/Profile/Queries/GetMyProfile/GetMyProfileQueryHandler.cs
+++ b/WhatsAppChat.Application/Features/Profile/Queries/GetMyProfile/GetMyProfileQueryHandler.cs
@@ -1,0 +1,27 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using WhatsAppChat.Application.DTOs.Profile;
+using WhatsAppChat.Domain.Entities;
+
+namespace WhatsAppChat.Application.Features.Profile.Queries.GetMyProfile;
+
+public class GetMyProfileQueryHandler : IRequestHandler<GetMyProfileQuery, ProfileDto>
+{
+    private readonly UserManager<AppUser> _userManager;
+
+    public GetMyProfileQueryHandler(UserManager<AppUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    public async Task<ProfileDto> Handle(GetMyProfileQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            throw new KeyNotFoundException("User not found");
+        }
+
+        return new ProfileDto(user.Id, user.DisplayName, user.AvatarUrl, user.About, user.LastSeen, user.LastSeenPrivacy.ToString());
+    }
+}

--- a/WhatsAppChat.Application/Features/Profile/Queries/GetMyProfile/GetMyProfileQueryValidator.cs
+++ b/WhatsAppChat.Application/Features/Profile/Queries/GetMyProfile/GetMyProfileQueryValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Profile.Queries.GetMyProfile;
+
+public class GetMyProfileQueryValidator : AbstractValidator<GetMyProfileQuery>
+{
+    public GetMyProfileQueryValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/Features/Profile/Queries/GetUserProfile/GetUserProfileQuery.cs
+++ b/WhatsAppChat.Application/Features/Profile/Queries/GetUserProfile/GetUserProfileQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WhatsAppChat.Application.DTOs.Profile;
+
+namespace WhatsAppChat.Application.Features.Profile.Queries.GetUserProfile;
+
+public record GetUserProfileQuery(string UserId) : IRequest<ProfileDto>;

--- a/WhatsAppChat.Application/Features/Profile/Queries/GetUserProfile/GetUserProfileQueryHandler.cs
+++ b/WhatsAppChat.Application/Features/Profile/Queries/GetUserProfile/GetUserProfileQueryHandler.cs
@@ -1,0 +1,29 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using WhatsAppChat.Application.DTOs.Profile;
+using WhatsAppChat.Domain.Entities;
+using WhatsAppChat.Domain.Enums;
+
+namespace WhatsAppChat.Application.Features.Profile.Queries.GetUserProfile;
+
+public class GetUserProfileQueryHandler : IRequestHandler<GetUserProfileQuery, ProfileDto>
+{
+    private readonly UserManager<AppUser> _userManager;
+
+    public GetUserProfileQueryHandler(UserManager<AppUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    public async Task<ProfileDto> Handle(GetUserProfileQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            throw new KeyNotFoundException("User not found");
+        }
+
+        DateTime? lastSeen = user.LastSeenPrivacy == LastSeenPrivacy.Everyone ? user.LastSeen : null;
+        return new ProfileDto(user.Id, user.DisplayName, user.AvatarUrl, user.About, lastSeen, user.LastSeenPrivacy.ToString());
+    }
+}

--- a/WhatsAppChat.Application/Features/Profile/Queries/GetUserProfile/GetUserProfileQueryValidator.cs
+++ b/WhatsAppChat.Application/Features/Profile/Queries/GetUserProfile/GetUserProfileQueryValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Profile.Queries.GetUserProfile;
+
+public class GetUserProfileQueryValidator : AbstractValidator<GetUserProfileQuery>
+{
+    public GetUserProfileQueryValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Domain/Entities/AppUser.cs
+++ b/WhatsAppChat.Domain/Entities/AppUser.cs
@@ -1,8 +1,15 @@
 using Microsoft.AspNetCore.Identity;
+using WhatsAppChat.Domain.Enums;
 
 namespace WhatsAppChat.Domain.Entities;
 
 public class AppUser : IdentityUser
 {
+    public string? DisplayName { get; set; }
+    public string? AvatarUrl { get; set; }
+    public string? About { get; set; }
+    public DateTime? LastSeen { get; set; }
+    public LastSeenPrivacy LastSeenPrivacy { get; set; } = LastSeenPrivacy.Everyone;
+
     public ICollection<RefreshToken> RefreshTokens { get; set; } = new List<RefreshToken>();
 }

--- a/WhatsAppChat.Domain/Enums/LastSeenPrivacy.cs
+++ b/WhatsAppChat.Domain/Enums/LastSeenPrivacy.cs
@@ -1,0 +1,7 @@
+namespace WhatsAppChat.Domain.Enums;
+
+public enum LastSeenPrivacy
+{
+    Everyone,
+    Nobody
+}

--- a/WhatsAppChat.Infrastructure/ServiceCollectionExtensions.cs
+++ b/WhatsAppChat.Infrastructure/ServiceCollectionExtensions.cs
@@ -29,8 +29,9 @@ public static class ServiceCollectionExtensions
 
         services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
         services.AddScoped<IJwtTokenService, JwtTokenService>();
+        services.AddScoped<IAvatarStorageService, AvatarStorageService>();
 
-        var jwtSettings = configuration.GetSection("JwtSettings").Get<JwtSettings>();
+        var jwtSettings = configuration.GetSection("JwtSettings").Get<JwtSettings>()!;
         var key = Encoding.UTF8.GetBytes(jwtSettings.Key);
 
         services.AddAuthentication(options =>

--- a/WhatsAppChat.Infrastructure/Services/AvatarStorageService.cs
+++ b/WhatsAppChat.Infrastructure/Services/AvatarStorageService.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Hosting;
+using WhatsAppChat.Application.Common.Interfaces;
+using System.IO;
+using System.Threading;
+
+namespace WhatsAppChat.Infrastructure.Services;
+
+public class AvatarStorageService : IAvatarStorageService
+{
+    private readonly string _avatarsPath;
+
+    public AvatarStorageService(IHostEnvironment environment)
+    {
+        _avatarsPath = Path.Combine(environment.ContentRootPath, "Avatars");
+        if (!Directory.Exists(_avatarsPath))
+        {
+            Directory.CreateDirectory(_avatarsPath);
+        }
+    }
+
+    public async Task<string> SaveAvatarAsync(string userId, Stream avatarStream, string fileName, CancellationToken cancellationToken = default)
+    {
+        var extension = Path.GetExtension(fileName);
+        var fileNameWithId = $"{userId}{extension}";
+        var filePath = Path.Combine(_avatarsPath, fileNameWithId);
+        using var fileStream = File.Create(filePath);
+        await avatarStream.CopyToAsync(fileStream, cancellationToken);
+        return $"avatars/{fileNameWithId}";
+    }
+}


### PR DESCRIPTION
## Summary
- extend AppUser with profile and privacy fields
- add profile DTOs, commands, queries, and validators
- implement avatar storage service and API controller

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a39e1ff08329a9ddcfce25d42926