### PR TITLE
Add conversation entities and operations

### DIFF
--- a/WhatsAppChat.Application/Common/Interfaces/IConversationRepository.cs
+++ b/WhatsAppChat.Application/Common/Interfaces/IConversationRepository.cs
@@ -1,0 +1,17 @@
+using WhatsAppChat.Domain.Entities;
+
+namespace WhatsAppChat.Application.Common.Interfaces;
+
+public interface IConversationRepository
+{
+    Task<Conversation> CreateOneToOneAsync(string userId1, string userId2);
+    Task<Conversation> CreateGroupAsync(Conversation conversation, IEnumerable<ConversationParticipant> participants);
+    Task UpdateGroupInfoAsync(Guid conversationId, string? title, string? photoUrl);
+    Task AddMembersAsync(Guid conversationId, IEnumerable<ConversationParticipant> participants);
+    Task RemoveMemberAsync(Guid conversationId, string userId);
+    Task LeaveGroupAsync(Guid conversationId, string userId);
+    Task PinConversationAsync(Guid conversationId, string userId, bool isPinned);
+    Task MuteConversationAsync(Guid conversationId, string userId, bool isMuted);
+    Task<List<Conversation>> GetConversationsForUserAsync(string userId);
+    Task<Conversation?> GetByIdAsync(Guid conversationId);
+}

--- a/WhatsAppChat.Application/DTOs/Conversations/AddMembersDto.cs
+++ b/WhatsAppChat.Application/DTOs/Conversations/AddMembersDto.cs
@@ -1,0 +1,3 @@
+namespace WhatsAppChat.Application.DTOs.Conversations;
+
+public record AddMembersDto(List<string> UserIds);

--- a/WhatsAppChat.Application/DTOs/Conversations/ConversationDto.cs
+++ b/WhatsAppChat.Application/DTOs/Conversations/ConversationDto.cs
@@ -1,0 +1,3 @@
+namespace WhatsAppChat.Application.DTOs.Conversations;
+
+public record ConversationDto(Guid Id, bool IsGroup, string? Title, string? PhotoUrl);

--- a/WhatsAppChat.Application/DTOs/Conversations/CreateGroupDto.cs
+++ b/WhatsAppChat.Application/DTOs/Conversations/CreateGroupDto.cs
@@ -1,0 +1,3 @@
+namespace WhatsAppChat.Application.DTOs.Conversations;
+
+public record CreateGroupDto(string Title, string? PhotoUrl, List<string> MemberIds);

--- a/WhatsAppChat.Application/DTOs/Conversations/CreateOneToOneDto.cs
+++ b/WhatsAppChat.Application/DTOs/Conversations/CreateOneToOneDto.cs
@@ -1,0 +1,3 @@
+namespace WhatsAppChat.Application.DTOs.Conversations;
+
+public record CreateOneToOneDto(string OtherUserId);

--- a/WhatsAppChat.Application/DTOs/Conversations/RemoveMemberDto.cs
+++ b/WhatsAppChat.Application/DTOs/Conversations/RemoveMemberDto.cs
@@ -1,0 +1,3 @@
+namespace WhatsAppChat.Application.DTOs.Conversations;
+
+public record RemoveMemberDto(string UserId);

--- a/WhatsAppChat.Application/DTOs/Conversations/UpdateGroupInfoDto.cs
+++ b/WhatsAppChat.Application/DTOs/Conversations/UpdateGroupInfoDto.cs
@@ -1,0 +1,3 @@
+namespace WhatsAppChat.Application.DTOs.Conversations;
+
+public record UpdateGroupInfoDto(string Title, string? PhotoUrl);

--- a/WhatsAppChat.Application/Features/Contacts/Commands/BlockUser/BlockUserCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Contacts/Commands/BlockUser/BlockUserCommandHandler.cs
@@ -13,7 +13,7 @@ public class BlockUserCommandHandler : IRequestHandler<BlockUserCommand>
         _blockRepository = blockRepository;
     }
 
-    public async Task Handle(BlockUserCommand request, CancellationToken cancellationToken)
+    public async Task<Unit> Handle(BlockUserCommand request, CancellationToken cancellationToken)
     {
         var block = new Block
         {
@@ -22,5 +22,6 @@ public class BlockUserCommandHandler : IRequestHandler<BlockUserCommand>
             CreatedAt = DateTime.UtcNow
         };
         await _blockRepository.AddAsync(block);
+        return Unit.Value;
     }
 }

--- a/WhatsAppChat.Application/Features/Contacts/Commands/RemoveContact/RemoveContactCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Contacts/Commands/RemoveContact/RemoveContactCommandHandler.cs
@@ -12,8 +12,9 @@ public class RemoveContactCommandHandler : IRequestHandler<RemoveContactCommand>
         _contactRepository = contactRepository;
     }
 
-    public async Task Handle(RemoveContactCommand request, CancellationToken cancellationToken)
+    public async Task<Unit> Handle(RemoveContactCommand request, CancellationToken cancellationToken)
     {
         await _contactRepository.RemoveAsync(request.OwnerUserId, request.ContactUserId);
+        return Unit.Value;
     }
 }

--- a/WhatsAppChat.Application/Features/Contacts/Commands/UnblockUser/UnblockUserCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Contacts/Commands/UnblockUser/UnblockUserCommandHandler.cs
@@ -12,8 +12,9 @@ public class UnblockUserCommandHandler : IRequestHandler<UnblockUserCommand>
         _blockRepository = blockRepository;
     }
 
-    public async Task Handle(UnblockUserCommand request, CancellationToken cancellationToken)
+    public async Task<Unit> Handle(UnblockUserCommand request, CancellationToken cancellationToken)
     {
         await _blockRepository.RemoveAsync(request.BlockerUserId, request.BlockedUserId);
+        return Unit.Value;
     }
 }

--- a/WhatsAppChat.Application/Features/Conversations/Commands/AddMembers/AddMembersCommand.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/AddMembers/AddMembersCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WhatsAppChat.Application.DTOs.Conversations;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.AddMembers;
+
+public record AddMembersCommand(Guid ConversationId, AddMembersDto MembersDto) : IRequest;

--- a/WhatsAppChat.Application/Features/Conversations/Commands/AddMembers/AddMembersCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/AddMembers/AddMembersCommandHandler.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using MediatR;
+using WhatsAppChat.Application.Common.Interfaces;
+using WhatsAppChat.Domain.Entities;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.AddMembers;
+
+public class AddMembersCommandHandler : IRequestHandler<AddMembersCommand>
+{
+    private readonly IConversationRepository _conversationRepository;
+
+    public AddMembersCommandHandler(IConversationRepository conversationRepository)
+    {
+        _conversationRepository = conversationRepository;
+    }
+
+    public async Task<Unit> Handle(AddMembersCommand request, CancellationToken cancellationToken)
+    {
+        var participants = request.MembersDto.UserIds.Select(id => new ConversationParticipant { UserId = id });
+        await _conversationRepository.AddMembersAsync(request.ConversationId, participants);
+        return Unit.Value;
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/AddMembers/AddMembersCommandValidator.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/AddMembers/AddMembersCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.AddMembers;
+
+public class AddMembersCommandValidator : AbstractValidator<AddMembersCommand>
+{
+    public AddMembersCommandValidator()
+    {
+        RuleFor(x => x.ConversationId).NotEmpty();
+        RuleFor(x => x.MembersDto.UserIds).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/CreateGroupConversation/CreateGroupConversationCommand.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/CreateGroupConversation/CreateGroupConversationCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WhatsAppChat.Application.DTOs.Conversations;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.CreateGroupConversation;
+
+public record CreateGroupConversationCommand(string CreatorUserId, CreateGroupDto GroupDto) : IRequest<ConversationDto>;

--- a/WhatsAppChat.Application/Features/Conversations/Commands/CreateGroupConversation/CreateGroupConversationCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/CreateGroupConversation/CreateGroupConversationCommandHandler.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using MediatR;
+using WhatsAppChat.Application.Common.Interfaces;
+using WhatsAppChat.Application.DTOs.Conversations;
+using WhatsAppChat.Domain.Entities;
+using WhatsAppChat.Domain.Enums;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.CreateGroupConversation;
+
+public class CreateGroupConversationCommandHandler : IRequestHandler<CreateGroupConversationCommand, ConversationDto>
+{
+    private readonly IConversationRepository _conversationRepository;
+
+    public CreateGroupConversationCommandHandler(IConversationRepository conversationRepository)
+    {
+        _conversationRepository = conversationRepository;
+    }
+
+    public async Task<ConversationDto> Handle(CreateGroupConversationCommand request, CancellationToken cancellationToken)
+    {
+        var conversation = new Conversation
+        {
+            IsGroup = true,
+            Title = request.GroupDto.Title,
+            PhotoUrl = request.GroupDto.PhotoUrl,
+            CreatedById = request.CreatorUserId
+        };
+
+        var participants = new List<ConversationParticipant>
+        {
+            new ConversationParticipant { UserId = request.CreatorUserId, Role = ConversationParticipantRole.Admin }
+        };
+        participants.AddRange(request.GroupDto.MemberIds.Select(id => new ConversationParticipant { UserId = id }));
+
+        var created = await _conversationRepository.CreateGroupAsync(conversation, participants);
+        return new ConversationDto(created.Id, created.IsGroup, created.Title, created.PhotoUrl);
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/CreateGroupConversation/CreateGroupConversationCommandValidator.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/CreateGroupConversation/CreateGroupConversationCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.CreateGroupConversation;
+
+public class CreateGroupConversationCommandValidator : AbstractValidator<CreateGroupConversationCommand>
+{
+    public CreateGroupConversationCommandValidator()
+    {
+        RuleFor(x => x.CreatorUserId).NotEmpty();
+        RuleFor(x => x.GroupDto.Title).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/CreateOneToOneConversation/CreateOneToOneConversationCommand.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/CreateOneToOneConversation/CreateOneToOneConversationCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WhatsAppChat.Application.DTOs.Conversations;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.CreateOneToOneConversation;
+
+public record CreateOneToOneConversationCommand(string CreatorUserId, CreateOneToOneDto ConversationDto) : IRequest<ConversationDto>;

--- a/WhatsAppChat.Application/Features/Conversations/Commands/CreateOneToOneConversation/CreateOneToOneConversationCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/CreateOneToOneConversation/CreateOneToOneConversationCommandHandler.cs
@@ -1,0 +1,21 @@
+using MediatR;
+using WhatsAppChat.Application.Common.Interfaces;
+using WhatsAppChat.Application.DTOs.Conversations;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.CreateOneToOneConversation;
+
+public class CreateOneToOneConversationCommandHandler : IRequestHandler<CreateOneToOneConversationCommand, ConversationDto>
+{
+    private readonly IConversationRepository _conversationRepository;
+
+    public CreateOneToOneConversationCommandHandler(IConversationRepository conversationRepository)
+    {
+        _conversationRepository = conversationRepository;
+    }
+
+    public async Task<ConversationDto> Handle(CreateOneToOneConversationCommand request, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversationRepository.CreateOneToOneAsync(request.CreatorUserId, request.ConversationDto.OtherUserId);
+        return new ConversationDto(conversation.Id, conversation.IsGroup, conversation.Title, conversation.PhotoUrl);
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/CreateOneToOneConversation/CreateOneToOneConversationCommandValidator.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/CreateOneToOneConversation/CreateOneToOneConversationCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.CreateOneToOneConversation;
+
+public class CreateOneToOneConversationCommandValidator : AbstractValidator<CreateOneToOneConversationCommand>
+{
+    public CreateOneToOneConversationCommandValidator()
+    {
+        RuleFor(x => x.CreatorUserId).NotEmpty();
+        RuleFor(x => x.ConversationDto.OtherUserId).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/LeaveGroup/LeaveGroupCommand.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/LeaveGroup/LeaveGroupCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.LeaveGroup;
+
+public record LeaveGroupCommand(Guid ConversationId, string UserId) : IRequest;

--- a/WhatsAppChat.Application/Features/Conversations/Commands/LeaveGroup/LeaveGroupCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/LeaveGroup/LeaveGroupCommandHandler.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using WhatsAppChat.Application.Common.Interfaces;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.LeaveGroup;
+
+public class LeaveGroupCommandHandler : IRequestHandler<LeaveGroupCommand>
+{
+    private readonly IConversationRepository _conversationRepository;
+
+    public LeaveGroupCommandHandler(IConversationRepository conversationRepository)
+    {
+        _conversationRepository = conversationRepository;
+    }
+
+    public async Task<Unit> Handle(LeaveGroupCommand request, CancellationToken cancellationToken)
+    {
+        await _conversationRepository.LeaveGroupAsync(request.ConversationId, request.UserId);
+        return Unit.Value;
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/LeaveGroup/LeaveGroupCommandValidator.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/LeaveGroup/LeaveGroupCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.LeaveGroup;
+
+public class LeaveGroupCommandValidator : AbstractValidator<LeaveGroupCommand>
+{
+    public LeaveGroupCommandValidator()
+    {
+        RuleFor(x => x.ConversationId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/MuteConversation/MuteConversationCommand.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/MuteConversation/MuteConversationCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.MuteConversation;
+
+public record MuteConversationCommand(Guid ConversationId, string UserId, bool IsMuted) : IRequest;

--- a/WhatsAppChat.Application/Features/Conversations/Commands/MuteConversation/MuteConversationCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/MuteConversation/MuteConversationCommandHandler.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using WhatsAppChat.Application.Common.Interfaces;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.MuteConversation;
+
+public class MuteConversationCommandHandler : IRequestHandler<MuteConversationCommand>
+{
+    private readonly IConversationRepository _conversationRepository;
+
+    public MuteConversationCommandHandler(IConversationRepository conversationRepository)
+    {
+        _conversationRepository = conversationRepository;
+    }
+
+    public async Task<Unit> Handle(MuteConversationCommand request, CancellationToken cancellationToken)
+    {
+        await _conversationRepository.MuteConversationAsync(request.ConversationId, request.UserId, request.IsMuted);
+        return Unit.Value;
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/MuteConversation/MuteConversationCommandValidator.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/MuteConversation/MuteConversationCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.MuteConversation;
+
+public class MuteConversationCommandValidator : AbstractValidator<MuteConversationCommand>
+{
+    public MuteConversationCommandValidator()
+    {
+        RuleFor(x => x.ConversationId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/PinConversation/PinConversationCommand.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/PinConversation/PinConversationCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.PinConversation;
+
+public record PinConversationCommand(Guid ConversationId, string UserId, bool IsPinned) : IRequest;

--- a/WhatsAppChat.Application/Features/Conversations/Commands/PinConversation/PinConversationCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/PinConversation/PinConversationCommandHandler.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using WhatsAppChat.Application.Common.Interfaces;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.PinConversation;
+
+public class PinConversationCommandHandler : IRequestHandler<PinConversationCommand>
+{
+    private readonly IConversationRepository _conversationRepository;
+
+    public PinConversationCommandHandler(IConversationRepository conversationRepository)
+    {
+        _conversationRepository = conversationRepository;
+    }
+
+    public async Task<Unit> Handle(PinConversationCommand request, CancellationToken cancellationToken)
+    {
+        await _conversationRepository.PinConversationAsync(request.ConversationId, request.UserId, request.IsPinned);
+        return Unit.Value;
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/PinConversation/PinConversationCommandValidator.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/PinConversation/PinConversationCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.PinConversation;
+
+public class PinConversationCommandValidator : AbstractValidator<PinConversationCommand>
+{
+    public PinConversationCommandValidator()
+    {
+        RuleFor(x => x.ConversationId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/RemoveMember/RemoveMemberCommand.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/RemoveMember/RemoveMemberCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WhatsAppChat.Application.DTOs.Conversations;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.RemoveMember;
+
+public record RemoveMemberCommand(Guid ConversationId, RemoveMemberDto MemberDto) : IRequest;

--- a/WhatsAppChat.Application/Features/Conversations/Commands/RemoveMember/RemoveMemberCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/RemoveMember/RemoveMemberCommandHandler.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using WhatsAppChat.Application.Common.Interfaces;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.RemoveMember;
+
+public class RemoveMemberCommandHandler : IRequestHandler<RemoveMemberCommand>
+{
+    private readonly IConversationRepository _conversationRepository;
+
+    public RemoveMemberCommandHandler(IConversationRepository conversationRepository)
+    {
+        _conversationRepository = conversationRepository;
+    }
+
+    public async Task<Unit> Handle(RemoveMemberCommand request, CancellationToken cancellationToken)
+    {
+        await _conversationRepository.RemoveMemberAsync(request.ConversationId, request.MemberDto.UserId);
+        return Unit.Value;
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/RemoveMember/RemoveMemberCommandValidator.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/RemoveMember/RemoveMemberCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.RemoveMember;
+
+public class RemoveMemberCommandValidator : AbstractValidator<RemoveMemberCommand>
+{
+    public RemoveMemberCommandValidator()
+    {
+        RuleFor(x => x.ConversationId).NotEmpty();
+        RuleFor(x => x.MemberDto.UserId).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/UpdateGroupInfo/UpdateGroupInfoCommand.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/UpdateGroupInfo/UpdateGroupInfoCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WhatsAppChat.Application.DTOs.Conversations;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.UpdateGroupInfo;
+
+public record UpdateGroupInfoCommand(Guid ConversationId, UpdateGroupInfoDto UpdateDto) : IRequest;

--- a/WhatsAppChat.Application/Features/Conversations/Commands/UpdateGroupInfo/UpdateGroupInfoCommandHandler.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/UpdateGroupInfo/UpdateGroupInfoCommandHandler.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using WhatsAppChat.Application.Common.Interfaces;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.UpdateGroupInfo;
+
+public class UpdateGroupInfoCommandHandler : IRequestHandler<UpdateGroupInfoCommand>
+{
+    private readonly IConversationRepository _conversationRepository;
+
+    public UpdateGroupInfoCommandHandler(IConversationRepository conversationRepository)
+    {
+        _conversationRepository = conversationRepository;
+    }
+
+    public async Task<Unit> Handle(UpdateGroupInfoCommand request, CancellationToken cancellationToken)
+    {
+        await _conversationRepository.UpdateGroupInfoAsync(request.ConversationId, request.UpdateDto.Title, request.UpdateDto.PhotoUrl);
+        return Unit.Value;
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Commands/UpdateGroupInfo/UpdateGroupInfoCommandValidator.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Commands/UpdateGroupInfo/UpdateGroupInfoCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Conversations.Commands.UpdateGroupInfo;
+
+public class UpdateGroupInfoCommandValidator : AbstractValidator<UpdateGroupInfoCommand>
+{
+    public UpdateGroupInfoCommandValidator()
+    {
+        RuleFor(x => x.ConversationId).NotEmpty();
+        RuleFor(x => x.UpdateDto.Title).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Queries/GetConversationById/GetConversationByIdQuery.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Queries/GetConversationById/GetConversationByIdQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WhatsAppChat.Application.DTOs.Conversations;
+
+namespace WhatsAppChat.Application.Features.Conversations.Queries.GetConversationById;
+
+public record GetConversationByIdQuery(Guid ConversationId) : IRequest<ConversationDto?>;

--- a/WhatsAppChat.Application/Features/Conversations/Queries/GetConversationById/GetConversationByIdQueryHandler.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Queries/GetConversationById/GetConversationByIdQueryHandler.cs
@@ -1,0 +1,21 @@
+using MediatR;
+using WhatsAppChat.Application.Common.Interfaces;
+using WhatsAppChat.Application.DTOs.Conversations;
+
+namespace WhatsAppChat.Application.Features.Conversations.Queries.GetConversationById;
+
+public class GetConversationByIdQueryHandler : IRequestHandler<GetConversationByIdQuery, ConversationDto?>
+{
+    private readonly IConversationRepository _conversationRepository;
+
+    public GetConversationByIdQueryHandler(IConversationRepository conversationRepository)
+    {
+        _conversationRepository = conversationRepository;
+    }
+
+    public async Task<ConversationDto?> Handle(GetConversationByIdQuery request, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversationRepository.GetByIdAsync(request.ConversationId);
+        return conversation is null ? null : new ConversationDto(conversation.Id, conversation.IsGroup, conversation.Title, conversation.PhotoUrl);
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Queries/GetConversationById/GetConversationByIdQueryValidator.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Queries/GetConversationById/GetConversationByIdQueryValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Conversations.Queries.GetConversationById;
+
+public class GetConversationByIdQueryValidator : AbstractValidator<GetConversationByIdQuery>
+{
+    public GetConversationByIdQueryValidator()
+    {
+        RuleFor(x => x.ConversationId).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Queries/GetMyConversations/GetMyConversationsQuery.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Queries/GetMyConversations/GetMyConversationsQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using WhatsAppChat.Application.DTOs.Conversations;
+
+namespace WhatsAppChat.Application.Features.Conversations.Queries.GetMyConversations;
+
+public record GetMyConversationsQuery(string UserId) : IRequest<List<ConversationDto>>;

--- a/WhatsAppChat.Application/Features/Conversations/Queries/GetMyConversations/GetMyConversationsQueryHandler.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Queries/GetMyConversations/GetMyConversationsQueryHandler.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Linq;
+using MediatR;
+using WhatsAppChat.Application.Common.Interfaces;
+using WhatsAppChat.Application.DTOs.Conversations;
+
+namespace WhatsAppChat.Application.Features.Conversations.Queries.GetMyConversations;
+
+public class GetMyConversationsQueryHandler : IRequestHandler<GetMyConversationsQuery, List<ConversationDto>>
+{
+    private readonly IConversationRepository _conversationRepository;
+
+    public GetMyConversationsQueryHandler(IConversationRepository conversationRepository)
+    {
+        _conversationRepository = conversationRepository;
+    }
+
+    public async Task<List<ConversationDto>> Handle(GetMyConversationsQuery request, CancellationToken cancellationToken)
+    {
+        var conversations = await _conversationRepository.GetConversationsForUserAsync(request.UserId);
+        return conversations.Select(c => new ConversationDto(c.Id, c.IsGroup, c.Title, c.PhotoUrl)).ToList();
+    }
+}

--- a/WhatsAppChat.Application/Features/Conversations/Queries/GetMyConversations/GetMyConversationsQueryValidator.cs
+++ b/WhatsAppChat.Application/Features/Conversations/Queries/GetMyConversations/GetMyConversationsQueryValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace WhatsAppChat.Application.Features.Conversations.Queries.GetMyConversations;
+
+public class GetMyConversationsQueryValidator : AbstractValidator<GetMyConversationsQuery>
+{
+    public GetMyConversationsQueryValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/WhatsAppChat.Application/WhatsAppChat.Application.csproj
+++ b/WhatsAppChat.Application/WhatsAppChat.Application.csproj
@@ -12,5 +12,6 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/WhatsAppChat.Domain/Entities/Conversation.cs
+++ b/WhatsAppChat.Domain/Entities/Conversation.cs
@@ -1,0 +1,15 @@
+using WhatsAppChat.Domain.Enums;
+
+namespace WhatsAppChat.Domain.Entities;
+
+public class Conversation
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public bool IsGroup { get; set; }
+    public string? Title { get; set; }
+    public string? PhotoUrl { get; set; }
+    public string CreatedById { get; set; } = default!;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public ICollection<ConversationParticipant> Participants { get; set; } = new List<ConversationParticipant>();
+}

--- a/WhatsAppChat.Domain/Entities/ConversationParticipant.cs
+++ b/WhatsAppChat.Domain/Entities/ConversationParticipant.cs
@@ -1,0 +1,13 @@
+using WhatsAppChat.Domain.Enums;
+
+namespace WhatsAppChat.Domain.Entities;
+
+public class ConversationParticipant
+{
+    public Guid ConversationId { get; set; }
+    public string UserId { get; set; } = default!;
+    public ConversationParticipantRole Role { get; set; } = ConversationParticipantRole.Member;
+    public DateTime JoinedAt { get; set; } = DateTime.UtcNow;
+    public bool IsPinned { get; set; }
+    public bool IsMuted { get; set; }
+}

--- a/WhatsAppChat.Domain/Enums/ConversationParticipantRole.cs
+++ b/WhatsAppChat.Domain/Enums/ConversationParticipantRole.cs
@@ -1,0 +1,7 @@
+namespace WhatsAppChat.Domain.Enums;
+
+public enum ConversationParticipantRole
+{
+    Member,
+    Admin
+}

--- a/WhatsAppChat.Infrastructure/Data/ApplicationDbContext.cs
+++ b/WhatsAppChat.Infrastructure/Data/ApplicationDbContext.cs
@@ -13,11 +13,18 @@ public class ApplicationDbContext : IdentityDbContext<AppUser>
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
     public DbSet<Contact> Contacts => Set<Contact>();
     public DbSet<Block> Blocks => Set<Block>();
+    public DbSet<Conversation> Conversations => Set<Conversation>();
+    public DbSet<ConversationParticipant> ConversationParticipants => Set<ConversationParticipant>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
         builder.Entity<Contact>().HasKey(c => new { c.OwnerUserId, c.ContactUserId });
         builder.Entity<Block>().HasKey(b => new { b.BlockerUserId, b.BlockedUserId });
+        builder.Entity<ConversationParticipant>().HasKey(cp => new { cp.ConversationId, cp.UserId });
+        builder.Entity<Conversation>()
+            .HasMany(c => c.Participants)
+            .WithOne()
+            .HasForeignKey(cp => cp.ConversationId);
     }
 }

--- a/WhatsAppChat.Infrastructure/Repositories/ConversationRepository.cs
+++ b/WhatsAppChat.Infrastructure/Repositories/ConversationRepository.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using WhatsAppChat.Application.Common.Interfaces;
+using WhatsAppChat.Domain.Entities;
+using WhatsAppChat.Domain.Enums;
+using WhatsAppChat.Infrastructure.Data;
+
+namespace WhatsAppChat.Infrastructure.Repositories;
+
+public class ConversationRepository : IConversationRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public ConversationRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Conversation> CreateOneToOneAsync(string userId1, string userId2)
+    {
+        var conversation = new Conversation
+        {
+            IsGroup = false,
+            CreatedById = userId1,
+            Participants =
+            {
+                new ConversationParticipant { UserId = userId1, Role = ConversationParticipantRole.Admin },
+                new ConversationParticipant { UserId = userId2, Role = ConversationParticipantRole.Member }
+            }
+        };
+        _context.Conversations.Add(conversation);
+        await _context.SaveChangesAsync();
+        return conversation;
+    }
+
+    public async Task<Conversation> CreateGroupAsync(Conversation conversation, IEnumerable<ConversationParticipant> participants)
+    {
+        conversation.Participants = participants.ToList();
+        _context.Conversations.Add(conversation);
+        await _context.SaveChangesAsync();
+        return conversation;
+    }
+
+    public async Task UpdateGroupInfoAsync(Guid conversationId, string? title, string? photoUrl)
+    {
+        var conversation = await _context.Conversations.FindAsync(conversationId);
+        if (conversation is null) return;
+        conversation.Title = title;
+        conversation.PhotoUrl = photoUrl;
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task AddMembersAsync(Guid conversationId, IEnumerable<ConversationParticipant> participants)
+    {
+        foreach (var participant in participants)
+        {
+            participant.ConversationId = conversationId;
+        }
+        _context.ConversationParticipants.AddRange(participants);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task RemoveMemberAsync(Guid conversationId, string userId)
+    {
+        var participant = await _context.ConversationParticipants.FindAsync(conversationId, userId);
+        if (participant is null) return;
+        _context.ConversationParticipants.Remove(participant);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task LeaveGroupAsync(Guid conversationId, string userId)
+    {
+        await RemoveMemberAsync(conversationId, userId);
+    }
+
+    public async Task PinConversationAsync(Guid conversationId, string userId, bool isPinned)
+    {
+        var participant = await _context.ConversationParticipants.FindAsync(conversationId, userId);
+        if (participant is null) return;
+        participant.IsPinned = isPinned;
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task MuteConversationAsync(Guid conversationId, string userId, bool isMuted)
+    {
+        var participant = await _context.ConversationParticipants.FindAsync(conversationId, userId);
+        if (participant is null) return;
+        participant.IsMuted = isMuted;
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<List<Conversation>> GetConversationsForUserAsync(string userId)
+    {
+        return await _context.Conversations
+            .Include(c => c.Participants)
+            .Where(c => c.Participants.Any(p => p.UserId == userId))
+            .ToListAsync();
+    }
+
+    public async Task<Conversation?> GetByIdAsync(Guid conversationId)
+    {
+        return await _context.Conversations
+            .Include(c => c.Participants)
+            .FirstOrDefaultAsync(c => c.Id == conversationId);
+    }
+}

--- a/WhatsAppChat.Infrastructure/ServiceCollectionExtensions.cs
+++ b/WhatsAppChat.Infrastructure/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
         services.AddScoped<IContactRepository, ContactRepository>();
         services.AddScoped<IBlockRepository, BlockRepository>();
+        services.AddScoped<IConversationRepository, ConversationRepository>();
         services.AddScoped<IJwtTokenService, JwtTokenService>();
         services.AddScoped<IAvatarStorageService, AvatarStorageService>();
 


### PR DESCRIPTION
## Summary
- add Conversation and ConversationParticipant entities with supporting enum
- introduce conversation repository and register with DI
- implement DTOs, commands, handlers, validators and queries for conversations
- fix contact command handlers to return Unit

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b1c48a3d908329ae5c8ed7b7fe6bf4